### PR TITLE
Copy protocolClasses in PNConfiguration's copyWithZone: implementation

### DIFF
--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -160,6 +160,7 @@ static NSString * const kPNConfigurationDeviceIDKey = @"PNConfigurationDeviceID"
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;
     configuration.restoreSubscription = self.shouldRestoreSubscription;
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
+    configuration.protocolClasses = self.protocolClasses;
     
     return configuration;
 }


### PR DESCRIPTION
We were not copying `protocolClasses` in `copyWithZone:`, so that change was made locally in the https://github.com/SymphonyOSF/SIOS-Client-App project.

To avoid having to version this dependency inside that project, I'm reproducing that change here.